### PR TITLE
Make Travis-CI faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ addons:
       - liblua5.1-0-dev
       - lua5.1
 
-rvm:
-  - 2.2.2
-
 before_install:
   - pip install --user cpp-coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,11 @@ addons:
       - libperl-dev
       - python-dev
       - python3-dev
-      - ruby1.9.1-dev
       - liblua5.1-0-dev
       - lua5.1
+
+rvm:
+  - 2.2.2
 
 before_install:
   - pip install --user cpp-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,15 @@ env:
 sudo: false
 
 addons:
-        apt:
-                packages:
-                        - lcov
-                        - libperl-dev
-                        - python-dev
-                        - python3-dev
-                        - ruby1.9.1-dev
-                        - liblua5.1-0-dev
-                        - lua5.1
+  apt:
+    packages:
+      - lcov
+      - libperl-dev
+      - python-dev
+      - python3-dev
+      - ruby1.9.1-dev
+      - liblua5.1-0-dev
+      - lua5.1
 
 before_install:
   - pip install --user cpp-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,25 @@ env:
   - COVERAGE=no TEST=yes FEATURES=small
   - COVERAGE=no TEST=yes FEATURES=tiny
 
+sudo: false
+
+addons:
+        apt:
+                packages:
+                        - lcov
+                        - libperl-dev
+                        - python-dev
+                        - python3-dev
+                        - ruby1.9.1-dev
+                        - liblua5.1-0-dev
+                        - lua5.1
+
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install libperl-dev python-dev python3-dev ruby1.9.1-dev liblua5.1-0-dev lua5.1
-  - sudo pip install cpp-coveralls
+  - pip install --user cpp-coveralls
 
 script: sh ./ci_run.sh
 
 after_success:
-  - if [ x"$COVERAGE" == "xyes" ] ; then cd vim && coveralls -b src -x .xs -e src/xxd -e src/if_perl.c --encodings utf-8 latin-1 EUC-KR; fi
+  - if [ x"$COVERAGE" == "xyes" ] ; then cd vim && ~/.local/bin/coveralls -b src -x .xs -e src/xxd -e src/if_perl.c --encodings utf-8 latin-1 EUC-KR; fi
 
 # vim:set sts=2 sw=2 tw=0 et:


### PR DESCRIPTION
See: http://docs.travis-ci.com/user/migrating-from-legacy/

現時点では ruby1.9.1-dev のインストールが許可されていない模様。
https://travis-ci.org/vim-jp/vim-ci/jobs/72924226#L88

> Disallowing packages: ruby1.9.1-dev